### PR TITLE
Added ConvertTo-Json to PowerShell Example when listing aliases

### DIFF
--- a/articles/governance/resource-graph/samples/starter.md
+++ b/articles/governance/resource-graph/samples/starter.md
@@ -295,7 +295,7 @@ az graph query -q "where type =~ 'Microsoft.Compute/virtualMachines' | limit 1 |
 ```
 
 ```azurepowershell-interactive
-Search-AzGraph -Query "where type =~ 'Microsoft.Compute/virtualMachines' | limit 1 | project aliases"
+Search-AzGraph -Query "where type =~ 'Microsoft.Compute/virtualMachines' | limit 1 | project aliases | ConvertTo-Json"
 ```
 
 ## <a name="distinct-alias-values"/>Show distinct values for a specific alias


### PR DESCRIPTION
Search-AzGraph -Query "where type =~ 'Microsoft.Compute/virtualMachines' | limit 1 | project aliases" will return a result similar to 
"
aliases
-------
@{Microsoft.Compute/virtualMachines/storageProfile.osDisk.createOption=FromImage; Microsoft.Compute/virtualMachines/networkProfile.networkInterfaces=System.Object[]; Microsoft.Compute/virtualMac… "

Adding ConvertTo-Json will return a result similar to using Az CLI